### PR TITLE
Fixed typographical error, changed auxilliary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ clean-applications.rb
 
 schema.sql
   The database schema, including data for some of the small 
-  auxilliary tables.
+  auxiliary tables.
 
 import-lgcsb-applications.sql
   A SQL script that imports the LGCSB application dump. Input


### PR DESCRIPTION
mhausenblas, I've corrected a typographical error in the documentation of the [odc2011](https://github.com/mhausenblas/odc2011) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
